### PR TITLE
Fix invalid HTML fragments

### DIFF
--- a/components/contact10.html
+++ b/components/contact10.html
@@ -61,17 +61,17 @@
           <div class="contact10-content1 thq-flex-row">
             <div class="contact10-content2">
               <h2 class="thq-heading-2">
-                <fragment class="contact10-fragment6">
+                
                   <span class="contact10-text21">Locations</span>
-                </fragment>
+                
               </h2>
               <p class="thq-body-large">
-                <fragment class="contact10-fragment4">
+                
                   <span class="contact10-text19">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                     Suspendisse varius enim in ero.
                   </span>
-                </fragment>
+                
               </p>
             </div>
           </div>
@@ -83,17 +83,17 @@
                 class="contact10-image1 thq-img-ratio-16-9"
               />
               <h3 class="contact10-text12 thq-heading-3">
-                <fragment class="contact10-fragment3">
+                
                   <span class="contact10-text18">Bucharest</span>
-                </fragment>
+                
               </h3>
               <p class="thq-body-large">
-                <fragment class="contact10-fragment1">
+                
                   <span class="contact10-text16">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                     Suspendisse varius enim in ero.
                   </span>
-                </fragment>
+                
               </p>
               <div class="contact10-container3">
                 <a
@@ -113,17 +113,17 @@
                 class="contact10-image2 thq-img-ratio-16-9"
               />
               <h3 class="contact10-text14 thq-heading-3">
-                <fragment class="contact10-fragment2">
+                
                   <span class="contact10-text17">Cluj - Napoca</span>
-                </fragment>
+                
               </h3>
               <p class="thq-body-large">
-                <fragment class="contact10-fragment5">
+                
                   <span class="contact10-text20">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                     Suspendisse varius enim in ero.
                   </span>
-                </fragment>
+                
               </p>
               <div class="contact10-container5">
                 <a

--- a/components/cta26.html
+++ b/components/cta26.html
@@ -63,28 +63,28 @@
               <div class="cta26-container2">
                 <div class="cta26-content">
                   <span class="thq-heading-2">
-                    <fragment class="cta26-fragment1">
+                    
                       <span class="cta26-text4">
                         Ready to transform your business with AI?
                       </span>
-                    </fragment>
+                    
                   </span>
                   <p class="thq-body-large">
-                    <fragment class="cta26-fragment2">
+                    
                       <span class="cta26-text5">
                         Contact us today to learn more about our AI tech
                         consulting services and how we can help automate and
                         optimize your business processes.
                       </span>
-                    </fragment>
+                    
                   </p>
                 </div>
                 <div class="cta26-actions">
                   <button type="button" class="thq-button-filled cta26-button">
                     <span>
-                      <fragment class="cta26-fragment3">
+                      
                         <span class="cta26-text6">Contact Us</span>
-                      </fragment>
+                      
                     </span>
                   </button>
                 </div>

--- a/components/features24.html
+++ b/components/features24.html
@@ -82,17 +82,17 @@
               </div>
               <div class="features24-content1">
                 <h2 class="thq-heading-2">
-                  <fragment class="features24-fragment2">
+                  
                     <span class="features24-text2">Call Center Automation</span>
-                  </fragment>
+                  
                 </h2>
                 <span class="thq-body-small">
-                  <fragment class="features24-fragment5">
+                  
                     <span class="features24-text5">
                       Utilize AI to automate call center operations for better
                       customer service.
                     </span>
-                  </fragment>
+                  
                 </span>
               </div>
             </div>
@@ -102,17 +102,17 @@
               </div>
               <div class="features24-content2">
                 <h2 class="thq-heading-2">
-                  <fragment class="features24-fragment3">
+                  
                     <span class="features24-text3">CRM Automation</span>
-                  </fragment>
+                  
                 </h2>
                 <span class="thq-body-small">
-                  <fragment class="features24-fragment4">
+                  
                     <span class="features24-text4">
                       Enhance CRM systems like Dynamics and Salesforce with AI
                       automation for improved efficiency.
                     </span>
-                  </fragment>
+                  
                 </span>
               </div>
             </div>
@@ -122,19 +122,19 @@
               </div>
               <div class="features24-content3">
                 <h2 class="thq-heading-2">
-                  <fragment class="features24-fragment1">
+                  
                     <span class="features24-text1">
                       Invoice Processing Automation
                     </span>
-                  </fragment>
+                  
                 </h2>
                 <span class="thq-body-small">
-                  <fragment class="features24-fragment6">
+                  
                     <span class="features24-text6">
                       Automate invoice processing and AP/AR reconciliation with
                       AI technology.
                     </span>
-                  </fragment>
+                  
                 </span>
               </div>
             </div>

--- a/components/features25.html
+++ b/components/features25.html
@@ -65,17 +65,17 @@
               </div>
               <div class="features25-content1">
                 <h2 class="thq-heading-2">
-                  <fragment class="features25-fragment3">
+                  
                     <span class="features25-text3">Call Center Automation</span>
-                  </fragment>
+                  
                 </h2>
                 <span class="thq-body-small">
-                  <fragment class="features25-fragment2">
+                  
                     <span class="features25-text2">
                       Automate call center operations using AI technology to
                       improve efficiency and customer satisfaction.
                     </span>
-                  </fragment>
+                  
                 </span>
               </div>
             </div>
@@ -85,17 +85,17 @@
               </div>
               <div class="features25-content2">
                 <h2 class="thq-heading-2">
-                  <fragment class="features25-fragment6">
+                  
                     <span class="features25-text6">Data Entry Automation</span>
-                  </fragment>
+                  
                 </h2>
                 <span class="thq-body-small">
-                  <fragment class="features25-fragment4">
+                  
                     <span class="features25-text4">
                       Streamline data entry processes through AI automation for
                       faster and more accurate data processing.
                     </span>
-                  </fragment>
+                  
                 </span>
               </div>
             </div>
@@ -105,17 +105,17 @@
               </div>
               <div class="features25-content3">
                 <h2 class="thq-heading-2">
-                  <fragment class="features25-fragment1">
+                  
                     <span class="features25-text1">CRM Automation</span>
-                  </fragment>
+                  
                 </h2>
                 <span class="thq-body-small">
-                  <fragment class="features25-fragment5">
+                  
                     <span class="features25-text5">
                       Enhance customer relationship management with AI
                       automation in Dynamics, Salesforce, and other CRM systems.
                     </span>
-                  </fragment>
+                  
                 </span>
               </div>
             </div>

--- a/components/footer4.html
+++ b/components/footer4.html
@@ -73,9 +73,9 @@
                 rel="noreferrer noopener"
                 class="thq-body-small"
               >
-                <fragment class="footer4-fragment8">
+                
                   <span class="footer4-text21">About Us</span>
-                </fragment>
+                
               </a>
               <a
                 href="https://example.com"
@@ -83,9 +83,9 @@
                 rel="noreferrer noopener"
                 class="thq-body-small"
               >
-                <fragment class="footer4-fragment4">
+                
                   <span class="footer4-text17">Services</span>
-                </fragment>
+                
               </a>
               <a
                 href="https://example.com"
@@ -93,9 +93,9 @@
                 rel="noreferrer noopener"
                 class="thq-body-small"
               >
-                <fragment class="footer4-fragment2">
+                
                   <span class="footer4-text15">Case Studies</span>
-                </fragment>
+                
               </a>
               <a
                 href="https://example.com"
@@ -103,9 +103,9 @@
                 rel="noreferrer noopener"
                 class="thq-body-small"
               >
-                <fragment class="footer4-fragment1">
+                
                   <span class="footer4-text14">Blog</span>
-                </fragment>
+                
               </a>
               <a
                 href="https://example.com"
@@ -113,9 +113,9 @@
                 rel="noreferrer noopener"
                 class="thq-body-small"
               >
-                <fragment class="footer4-fragment3">
+                
                   <span class="footer4-text16">Contact Us</span>
-                </fragment>
+                
               </a>
             </div>
           </div>
@@ -127,19 +127,19 @@
               </div>
               <div class="footer4-footer-links">
                 <span class="footer4-text11 thq-body-small">
-                  <fragment class="footer4-fragment7">
+                  
                     <span class="footer4-text20">Privacy Policy</span>
-                  </fragment>
+                  
                 </span>
                 <span class="thq-body-small">
-                  <fragment class="footer4-fragment6">
+                  
                     <span class="footer4-text19">Terms of Service</span>
-                  </fragment>
+                  
                 </span>
                 <span class="thq-body-small">
-                  <fragment class="footer4-fragment5">
+                  
                     <span class="footer4-text18">Cookies Policy</span>
-                  </fragment>
+                  
                 </span>
               </div>
             </div>

--- a/components/hero17.html
+++ b/components/hero17.html
@@ -60,33 +60,33 @@
         <div class="hero17-column thq-section-max-width thq-section-padding">
           <div class="hero17-content1">
             <h1 class="hero17-text1 thq-heading-1">
-              <fragment class="hero17-fragment4">
+              
                 <span class="hero17-text8">AI Tech Consulting Services</span>
-              </fragment>
+              
             </h1>
             <p class="hero17-text2 thq-body-large">
-              <fragment class="hero17-fragment1">
+              
                 <span class="hero17-text5">
                   ExpertTech Consulting LLC in Boston specializes in providing
                   expert resources for automating various processes using the
                   latest AI technologies.
                 </span>
-              </fragment>
+              
             </p>
           </div>
           <div class="hero17-actions">
             <button class="thq-button-filled hero17-button1">
               <span class="thq-body-small">
-                <fragment class="hero17-fragment3">
+                
                   <span class="hero17-text7">Contact us</span>
-                </fragment>
+                
               </span>
             </button>
             <button class="thq-button-outline hero17-button2">
               <span class="thq-body-small">
-                <fragment class="hero17-fragment2">
+                
                   <span class="hero17-text6">Learn more</span>
-                </fragment>
+                
               </span>
             </button>
           </div>

--- a/components/navbar8.html
+++ b/components/navbar8.html
@@ -69,17 +69,17 @@
                 href="https://www.teleporthq.io"
                 class="navbar8-link11 thq-link thq-body-small"
               >
-                <fragment class="navbar8-fragment10">
+                
                   <span class="navbar8-text14">#home</span>
-                </fragment>
+                
               </a>
               <a
                 href="https://www.teleporthq.io"
                 class="thq-link thq-body-small"
               >
-                <fragment class="navbar8-fragment11">
+                
                   <span class="navbar8-text15">#services</span>
-                </fragment>
+                
               </a>
               <a
                 href="https://www.teleporthq.io"
@@ -87,15 +87,15 @@
                 rel="noreferrer noopener"
                 class="navbar8-link31 thq-link thq-body-small"
               >
-                <fragment class="navbar8-fragment14">
+                
                   <span class="navbar8-text18">#about</span>
-                </fragment>
+                
               </a>
               <div class="navbar8-link4-dropdown-trigger">
                 <span class="thq-link thq-body-small">
-                  <fragment class="navbar8-fragment12">
+                  
                     <span class="navbar8-text16">#contact</span>
-                  </fragment>
+                  
                 </span>
                 <div class="navbar8-icon-container1">
                   <div class="navbar8-container2">
@@ -116,18 +116,18 @@
                 class="navbar8-action11 thq-button-animated thq-button-filled"
               >
                 <span>
-                  <fragment class="navbar8-fragment15">
+                  
                     <span class="navbar8-text19">Learn More</span>
-                  </fragment>
+                  
                 </span>
               </button>
               <button
                 class="navbar8-action21 thq-button-outline thq-button-animated"
               >
                 <span>
-                  <fragment class="navbar8-fragment13">
+                  
                     <span class="navbar8-text17">Get in Touch</span>
-                  </fragment>
+                  
                 </span>
               </button>
             </div>
@@ -160,32 +160,32 @@
                   href="https://www.teleporthq.io"
                   class="navbar8-link12 thq-link thq-body-small"
                 >
-                  <fragment class="navbar8-fragment10">
+                  
                     <span class="navbar8-text14">#home</span>
-                  </fragment>
+                  
                 </a>
                 <a
                   href="https://www.teleporthq.io"
                   class="thq-link thq-body-small"
                 >
-                  <fragment class="navbar8-fragment11">
+                  
                     <span class="navbar8-text15">#services</span>
-                  </fragment>
+                  
                 </a>
                 <a
                   href="https://www.teleporthq.io"
                   class="navbar8-link32 thq-link thq-body-small"
                 >
-                  <fragment class="navbar8-fragment14">
+                  
                     <span class="navbar8-text18">#about</span>
-                  </fragment>
+                  
                 </a>
                 <div class="navbar8-link4-accordion">
                   <div class="navbar8-trigger">
                     <span class="thq-link thq-body-small">
-                      <fragment class="navbar8-fragment12">
+                      
                         <span class="navbar8-text16">#contact</span>
-                      </fragment>
+                      
                     </span>
                     <div class="navbar8-icon-container2">
                       <div class="navbar8-container4">
@@ -210,16 +210,16 @@
                         />
                         <div class="navbar8-content1">
                           <span class="navbar8-page11 thq-body-large">
-                            <fragment class="navbar8-fragment21">
+                            
                               <span class="navbar8-text25">Home</span>
-                            </fragment>
+                            
                           </span>
                           <span class="thq-body-small">
-                            <fragment class="navbar8-fragment19">
+                            
                               <span class="navbar8-text23">
                                 Welcome to ExpertTech Consulting LLC
                               </span>
-                            </fragment>
+                            
                           </span>
                         </div>
                       </div>
@@ -233,14 +233,14 @@
                         />
                         <div class="navbar8-content2">
                           <span class="navbar8-page21 thq-body-large">
-                            <fragment class="navbar8-fragment22">
+                            
                               <span class="navbar8-text26">Services</span>
-                            </fragment>
+                            
                           </span>
                           <span class="thq-body-small">
-                            <fragment class="navbar8-fragment18">
+                            
                               <span class="navbar8-text22">Our Services</span>
-                            </fragment>
+                            
                           </span>
                         </div>
                       </div>
@@ -254,16 +254,16 @@
                         />
                         <div class="navbar8-content3">
                           <span class="navbar8-page31 thq-body-large">
-                            <fragment class="navbar8-fragment16">
+                            
                               <span class="navbar8-text20">About Us</span>
-                            </fragment>
+                            
                           </span>
                           <span class="thq-body-small">
-                            <fragment class="navbar8-fragment23">
+                            
                               <span class="navbar8-text27">
                                 About ExpertTech Consulting LLC
                               </span>
-                            </fragment>
+                            
                           </span>
                         </div>
                       </div>
@@ -277,14 +277,14 @@
                         />
                         <div class="navbar8-content4">
                           <span class="navbar8-page41 thq-body-large">
-                            <fragment class="navbar8-fragment20">
+                            
                               <span class="navbar8-text24">Contact</span>
-                            </fragment>
+                            
                           </span>
                           <span class="thq-body-small">
-                            <fragment class="navbar8-fragment17">
+                            
                               <span class="navbar8-text21">Contact Us</span>
-                            </fragment>
+                            
                           </span>
                         </div>
                       </div>
@@ -295,16 +295,16 @@
               <div class="navbar8-buttons2">
                 <button class="thq-button-filled">
                   <span>
-                    <fragment class="navbar8-fragment15">
+                    
                       <span class="navbar8-text19">Learn More</span>
-                    </fragment>
+                    
                   </span>
                 </button>
                 <button class="thq-button-outline">
                   <span>
-                    <fragment class="navbar8-fragment13">
+                    
                       <span class="navbar8-text17">Get in Touch</span>
-                    </fragment>
+                    
                   </span>
                 </button>
               </div>
@@ -342,16 +342,16 @@
                   />
                   <div class="navbar8-content5">
                     <span class="navbar8-page12 thq-body-large">
-                      <fragment class="navbar8-fragment21">
+                      
                         <span class="navbar8-text25">Home</span>
-                      </fragment>
+                      
                     </span>
                     <span class="thq-body-small">
-                      <fragment class="navbar8-fragment19">
+                      
                         <span class="navbar8-text23">
                           Welcome to ExpertTech Consulting LLC
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -365,14 +365,14 @@
                   />
                   <div class="navbar8-content6">
                     <span class="navbar8-page22 thq-body-large">
-                      <fragment class="navbar8-fragment22">
+                      
                         <span class="navbar8-text26">Services</span>
-                      </fragment>
+                      
                     </span>
                     <span class="thq-body-small">
-                      <fragment class="navbar8-fragment18">
+                      
                         <span class="navbar8-text22">Our Services</span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -386,16 +386,16 @@
                   />
                   <div class="navbar8-content7">
                     <span class="navbar8-page32 thq-body-large">
-                      <fragment class="navbar8-fragment16">
+                      
                         <span class="navbar8-text20">About Us</span>
-                      </fragment>
+                      
                     </span>
                     <span class="thq-body-small">
-                      <fragment class="navbar8-fragment23">
+                      
                         <span class="navbar8-text27">
                           About ExpertTech Consulting LLC
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -409,14 +409,14 @@
                   />
                   <div class="navbar8-content8">
                     <span class="navbar8-page42 thq-body-large">
-                      <fragment class="navbar8-fragment20">
+                      
                         <span class="navbar8-text24">Contact</span>
-                      </fragment>
+                      
                     </span>
                     <span class="thq-body-small">
-                      <fragment class="navbar8-fragment17">
+                      
                         <span class="navbar8-text21">Contact Us</span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>

--- a/components/pricing14.html
+++ b/components/pricing14.html
@@ -60,24 +60,24 @@
         <div class="pricing14-max-width thq-section-max-width">
           <div class="pricing14-section-title">
             <span class="pricing14-text100 thq-body-small">
-              <fragment class="pricing14-fragment59">
+              
                 <span class="pricing14-text204">
                   Choose the perfect plan for you
                 </span>
-              </fragment>
+              
             </span>
             <div class="pricing14-content">
               <h2 class="pricing14-text101 thq-heading-2">
-                <fragment class="pricing14-fragment28">
+                
                   <span class="pricing14-text173">Pricing plan</span>
-                </fragment>
+                
               </h2>
               <p class="pricing14-text102 thq-body-large">
-                <fragment class="pricing14-fragment43">
+                
                   <span class="pricing14-text188">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                   </span>
-                </fragment>
+                
               </p>
             </div>
           </div>
@@ -108,19 +108,19 @@
               <div class="pricing14-price10">
                 <div class="pricing14-price11">
                   <p class="pricing14-text107 thq-body-large">
-                    <fragment class="pricing14-fragment12">
+                    
                       <span class="pricing14-text157">Basic Plan</span>
-                    </fragment>
+                    
                   </p>
                   <h3 class="pricing14-text108 thq-heading-3">
-                    <fragment class="pricing14-fragment44">
+                    
                       <span class="pricing14-text189">$99/month</span>
-                    </fragment>
+                    
                   </h3>
                   <p class="thq-body-large">
-                    <fragment class="pricing14-fragment45">
+                    
                       <span class="pricing14-text190">$999/year</span>
-                    </fragment>
+                    
                   </p>
                 </div>
                 <div class="pricing14-list1">
@@ -131,11 +131,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment31">
+                      
                         <span class="pricing14-text176">
                           Automate Call Center
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item11">
@@ -145,11 +145,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment56">
+                      
                         <span class="pricing14-text201">
                           Data Entry Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item12">
@@ -159,11 +159,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment41">
+                      
                         <span class="pricing14-text186">
                           CRM Automation - Dynamics, Salesforce, etc.
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -172,9 +172,9 @@
                 class="pricing14-button14 thq-button-outline thq-button-animated"
               >
                 <span class="thq-body-small">
-                  <fragment class="pricing14-fragment58">
+                  
                     <span class="pricing14-text203">Sign Up Now</span>
-                  </fragment>
+                  
                 </span>
               </button>
             </div>
@@ -182,19 +182,19 @@
               <div class="pricing14-price12">
                 <div class="pricing14-price13">
                   <p class="pricing14-text114 thq-body-large">
-                    <fragment class="pricing14-fragment29">
+                    
                       <span class="pricing14-text174">Standard Plan</span>
-                    </fragment>
+                    
                   </p>
                   <h3 class="pricing14-text115 thq-heading-3">
-                    <fragment class="pricing14-fragment47">
+                    
                       <span class="pricing14-text192">$199/month</span>
-                    </fragment>
+                    
                   </h3>
                   <p class="thq-body-large">
-                    <fragment class="pricing14-fragment16">
+                    
                       <span class="pricing14-text161">$1999/year</span>
-                    </fragment>
+                    
                   </p>
                 </div>
                 <div class="pricing14-list2">
@@ -205,11 +205,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment32">
+                      
                         <span class="pricing14-text177">
                           Telephony Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item14">
@@ -219,12 +219,12 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment22">
+                      
                         <span class="pricing14-text167">
                           Legacy Apps AI Automation through Vision and Scraping
                           Technology
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item15">
@@ -234,11 +234,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment38">
+                      
                         <span class="pricing14-text183">
                           Marketing Lead Generation Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item16">
@@ -248,11 +248,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment42">
+                      
                         <span class="pricing14-text187">
                           Data Entry Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -261,9 +261,9 @@
                 class="pricing14-button15 thq-button-animated thq-button-filled"
               >
                 <span class="thq-body-small">
-                  <fragment class="pricing14-fragment23">
+                  
                     <span class="pricing14-text168">Sign Up Now</span>
-                  </fragment>
+                  
                 </span>
               </button>
             </div>
@@ -271,19 +271,19 @@
               <div class="pricing14-price14">
                 <div class="pricing14-price15">
                   <p class="pricing14-text122 thq-body-large">
-                    <fragment class="pricing14-fragment33">
+                    
                       <span class="pricing14-text178">Premium Plan</span>
-                    </fragment>
+                    
                   </p>
                   <h3 class="pricing14-text123 thq-heading-3">
-                    <fragment class="pricing14-fragment13">
+                    
                       <span class="pricing14-text158">$299/month</span>
-                    </fragment>
+                    
                   </h3>
                   <p class="thq-body-large">
-                    <fragment class="pricing14-fragment46">
+                    
                       <span class="pricing14-text191">$2999/year</span>
-                    </fragment>
+                    
                   </p>
                 </div>
                 <div class="pricing14-list3">
@@ -294,11 +294,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment60">
+                      
                         <span class="pricing14-text205">
                           AI Automation for Call Center Operations
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item18">
@@ -308,11 +308,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment51">
+                      
                         <span class="pricing14-text196">
                           Telephony Automation with AI Integration
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item19">
@@ -322,11 +322,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment50">
+                      
                         <span class="pricing14-text195">
                           Data Entry and Invoice Processing Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item20">
@@ -336,11 +336,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment19">
+                      
                         <span class="pricing14-text164">
                           AP/AR Reconciliation with AI Technology
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item21">
@@ -350,11 +350,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment35">
+                      
                         <span class="pricing14-text180">
                           CRM Automation - Dynamics, Salesforce, etc.
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -363,9 +363,9 @@
                 class="pricing14-button16 thq-button-animated thq-button-filled"
               >
                 <span class="thq-body-small">
-                  <fragment class="pricing14-fragment11">
+                  
                     <span class="pricing14-text156">Sign Up Now</span>
-                  </fragment>
+                  
                 </span>
               </button>
             </div>
@@ -375,19 +375,19 @@
               <div class="pricing14-price16">
                 <div class="pricing14-price17">
                   <span class="pricing14-text131 thq-body-large">
-                    <fragment class="pricing14-fragment27">
+                    
                       <span class="pricing14-text172">Basic plan</span>
-                    </fragment>
+                    
                   </span>
                   <h3 class="pricing14-text132 thq-heading-3">
-                    <fragment class="pricing14-fragment14">
+                    
                       <span class="pricing14-text159">$200/yr</span>
-                    </fragment>
+                    
                   </h3>
                   <span class="thq-body-large">
-                    <fragment class="pricing14-fragment57">
+                    
                       <span class="pricing14-text202">or $20 monthly</span>
-                    </fragment>
+                    
                   </span>
                 </div>
                 <div class="pricing14-list4">
@@ -398,11 +398,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment20">
+                      
                         <span class="pricing14-text165">
                           Invoice Processing Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item23">
@@ -412,11 +412,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment10">
+                      
                         <span class="pricing14-text155">
                           AP/AR Reconciliation Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item24">
@@ -426,11 +426,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment18">
+                      
                         <span class="pricing14-text163">
                           Marketing Lead Generation Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -439,9 +439,9 @@
                 class="pricing14-button17 thq-button-outline thq-button-animated"
               >
                 <span class="thq-body-small">
-                  <fragment class="pricing14-fragment37">
+                  
                     <span class="pricing14-text182">Get started</span>
-                  </fragment>
+                  
                 </span>
               </button>
             </div>
@@ -449,19 +449,19 @@
               <div class="pricing14-price18">
                 <div class="pricing14-price19">
                   <span class="pricing14-text138 thq-body-large">
-                    <fragment class="pricing14-fragment26">
+                    
                       <span class="pricing14-text171">Business plan</span>
-                    </fragment>
+                    
                   </span>
                   <h3 class="pricing14-text139 thq-heading-3">
-                    <fragment class="pricing14-fragment17">
+                    
                       <span class="pricing14-text162">$299/yr</span>
-                    </fragment>
+                    
                   </h3>
                   <span class="thq-body-large">
-                    <fragment class="pricing14-fragment30">
+                    
                       <span class="pricing14-text175">or $29 monthly</span>
-                    </fragment>
+                    
                   </span>
                 </div>
                 <div class="pricing14-list5">
@@ -472,11 +472,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment36">
+                      
                         <span class="pricing14-text181">
                           Invoice Processing Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item26">
@@ -486,11 +486,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment24">
+                      
                         <span class="pricing14-text169">
                           AP/AR Reconciliation Automation
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item27">
@@ -500,11 +500,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment52">
+                      
                         <span class="pricing14-text197">
                           CRM Automation - Dynamics, Salesforce, etc.
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item28">
@@ -514,11 +514,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment40">
+                      
                         <span class="pricing14-text185">
                           Feature text goes here
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -527,9 +527,9 @@
                 class="pricing14-button18 thq-button-animated thq-button-filled"
               >
                 <span class="thq-body-small">
-                  <fragment class="pricing14-fragment48">
+                  
                     <span class="pricing14-text193">Get started</span>
-                  </fragment>
+                  
                 </span>
               </button>
             </div>
@@ -537,19 +537,19 @@
               <div class="pricing14-price20">
                 <div class="pricing14-price21">
                   <span class="pricing14-text146 thq-body-large">
-                    <fragment class="pricing14-fragment34">
+                    
                       <span class="pricing14-text179">Enterprise plan</span>
-                    </fragment>
+                    
                   </span>
                   <h3 class="pricing14-text147 thq-heading-3">
-                    <fragment class="pricing14-fragment53">
+                    
                       <span class="pricing14-text198">$499/yr</span>
-                    </fragment>
+                    
                   </h3>
                   <span class="thq-body-large">
-                    <fragment class="pricing14-fragment15">
+                    
                       <span class="pricing14-text160">or $49 monthly</span>
-                    </fragment>
+                    
                   </span>
                 </div>
                 <div class="pricing14-list6">
@@ -560,11 +560,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment25">
+                      
                         <span class="pricing14-text170">
                           Marketing Lead Generation with Advanced AI Algorithms
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item30">
@@ -574,12 +574,12 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment49">
+                      
                         <span class="pricing14-text194">
                           Legacy Apps AI Integration through Vision and Scraping
                           Technology
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item31">
@@ -589,11 +589,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment54">
+                      
                         <span class="pricing14-text199">
                           Feature text goes here
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item32">
@@ -603,11 +603,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment39">
+                      
                         <span class="pricing14-text184">
                           Feature text goes here
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                   <div class="pricing14-list-item33">
@@ -617,11 +617,11 @@
                       ></path>
                     </svg>
                     <span class="thq-body-small">
-                      <fragment class="pricing14-fragment21">
+                      
                         <span class="pricing14-text166">
                           Feature text goes here
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -630,9 +630,9 @@
                 class="pricing14-button19 thq-button-animated thq-button-filled"
               >
                 <span class="thq-body-small">
-                  <fragment class="pricing14-fragment55">
+                  
                     <span class="pricing14-text200">Get started</span>
-                  </fragment>
+                  
                 </span>
               </button>
             </div>

--- a/components/steps2.html
+++ b/components/steps2.html
@@ -79,70 +79,70 @@
             <div class="steps2-container3">
               <div class="steps2-container4 thq-card">
                 <h2 class="thq-heading-2">
-                  <fragment class="steps2-fragment3">
+                  
                     <span class="steps2-text27">Initial Consultation</span>
-                  </fragment>
+                  
                 </h2>
                 <span class="steps2-text14 thq-body-small">
-                  <fragment class="steps2-fragment8">
+                  
                     <span class="steps2-text32">
                       Schedule a meeting with our AI tech experts to discuss
                       your business needs and goals.
                     </span>
-                  </fragment>
+                  
                 </span>
                 <label class="steps2-text15 thq-heading-3">01</label>
               </div>
               <div class="steps2-container5 thq-card">
                 <h2 class="thq-heading-2">
-                  <fragment class="steps2-fragment2">
+                  
                     <span class="steps2-text26">
                       Customized Solution Design
                     </span>
-                  </fragment>
+                  
                 </h2>
                 <span class="steps2-text17 thq-body-small">
-                  <fragment class="steps2-fragment1">
+                  
                     <span class="steps2-text25">
                       Our team will design a tailored AI solution based on the
                       consultation to meet your specific requirements.
                     </span>
-                  </fragment>
+                  
                 </span>
                 <label class="steps2-text18 thq-heading-3">02</label>
               </div>
               <div class="steps2-container6 thq-card">
                 <h2 class="thq-heading-2">
-                  <fragment class="steps2-fragment7">
+                  
                     <span class="steps2-text31">
                       Implementation and Integration
                     </span>
-                  </fragment>
+                  
                 </h2>
                 <span class="steps2-text20 thq-body-small">
-                  <fragment class="steps2-fragment6">
+                  
                     <span class="steps2-text30">
                       We will implement the AI solution seamlessly into your
                       existing systems and ensure smooth integration.
                     </span>
-                  </fragment>
+                  
                 </span>
                 <label class="steps2-text21 thq-heading-3">03</label>
               </div>
               <div class="steps2-container7 thq-card">
                 <h2 class="thq-heading-2">
-                  <fragment class="steps2-fragment5">
+                  
                     <span class="steps2-text29">Training and Support</span>
-                  </fragment>
+                  
                 </h2>
                 <span class="steps2-text23 thq-body-small">
-                  <fragment class="steps2-fragment4">
+                  
                     <span class="steps2-text28">
                       Provide training to your team on how to use the new AI
                       technology effectively and offer ongoing support for any
                       assistance needed.
                     </span>
-                  </fragment>
+                  
                 </span>
                 <label class="steps2-text24 thq-heading-3">04</label>
               </div>

--- a/components/testimonial17.html
+++ b/components/testimonial17.html
@@ -60,18 +60,18 @@
         <div class="testimonial17-max-width thq-section-max-width">
           <div class="testimonial17-container10">
             <h2 class="thq-heading-2">
-              <fragment class="testimonial17-fragment10">
+              
                 <span class="testimonial17-text24">Testimonials</span>
-              </fragment>
+              
             </h2>
             <span class="testimonial17-text11 thq-body-small">
-              <fragment class="testimonial17-fragment23">
+              
                 <span class="testimonial17-text37">
                   ExpertTech Consulting LLC helped us automate our call center
                   operations efficiently. Their AI solutions have significantly
                   improved our customer service and overall productivity.
                 </span>
-              </fragment>
+              
             </span>
           </div>
           <div class="thq-grid-2">
@@ -86,27 +86,27 @@
                     />
                     <div class="testimonial17-container13">
                       <strong class="thq-body-large">
-                        <fragment class="testimonial17-fragment22">
+                        
                           <span class="testimonial17-text36">John Smith</span>
-                        </fragment>
+                        
                       </strong>
                       <span class="thq-body-small">
-                        <fragment class="testimonial17-fragment18">
+                        
                           <span class="testimonial17-text32">
                             CEO, ABC Inc.
                           </span>
-                        </fragment>
+                        
                       </span>
                     </div>
                   </div>
                   <span class="testimonial17-text14 thq-body-small">
-                    <fragment class="testimonial17-fragment11">
+                    
                       <span class="testimonial17-text25">
                         We are extremely satisfied with the services provided by
                         ExpertTech Consulting LLC. Their team is highly skilled
                         and professional.
                       </span>
-                    </fragment>
+                    
                   </span>
                 </div>
               </div>
@@ -122,30 +122,30 @@
                     />
                     <div class="testimonial17-container15">
                       <strong class="thq-body-large">
-                        <fragment class="testimonial17-fragment14">
+                        
                           <span class="testimonial17-text28">
                             Emily Johnson
                           </span>
-                        </fragment>
+                        
                       </strong>
                       <span class="thq-body-small">
-                        <fragment class="testimonial17-fragment15">
+                        
                           <span class="testimonial17-text29">
                             CFO, XYZ Corp.
                           </span>
-                        </fragment>
+                        
                       </span>
                     </div>
                   </div>
                   <span class="testimonial17-text17 thq-body-small">
-                    <fragment class="testimonial17-fragment17">
+                    
                       <span class="testimonial17-text31">
                         ExpertTech Consulting LLC's AI automation for invoice
                         processing has streamlined our financial operations. We
                         highly recommend their services for any business looking
                         to enhance efficiency.
                       </span>
-                    </fragment>
+                    
                   </span>
                 </div>
               </div>
@@ -161,27 +161,27 @@
                     />
                     <div class="testimonial17-container17">
                       <strong class="thq-body-large">
-                        <fragment class="testimonial17-fragment21">
+                        
                           <span class="testimonial17-text35">
                             Michael Brown
                           </span>
-                        </fragment>
+                        
                       </strong>
                       <span class="thq-body-small">
-                        <fragment class="testimonial17-fragment19">
+                        
                           <span class="testimonial17-text33">CTO, LMN Co.</span>
-                        </fragment>
+                        
                       </span>
                     </div>
                   </div>
                   <span class="testimonial17-text20 thq-body-small">
-                    <fragment class="testimonial17-fragment20">
+                    
                       <span class="testimonial17-text34">
                         The CRM automation solutions provided by ExpertTech
                         Consulting LLC have transformed our sales processes.
                         Their expertise in AI technology is truly commendable.
                       </span>
-                    </fragment>
+                    
                   </span>
                 </div>
               </div>
@@ -197,28 +197,28 @@
                     />
                     <div class="testimonial17-container19">
                       <strong class="thq-body-large">
-                        <fragment class="testimonial17-fragment16">
+                        
                           <span class="testimonial17-text30">Sarah Wilson</span>
-                        </fragment>
+                        
                       </strong>
                       <span class="thq-body-small">
-                        <fragment class="testimonial17-fragment13">
+                        
                           <span class="testimonial17-text27">
                             Marketing Manager, PQR Ltd.
                           </span>
-                        </fragment>
+                        
                       </span>
                     </div>
                   </div>
                   <span class="testimonial17-text23 thq-body-small">
-                    <fragment class="testimonial17-fragment12">
+                    
                       <span class="testimonial17-text26">
                         ExpertTech Consulting LLC's AI lead generation services
                         have significantly boosted our marketing efforts. We are
                         thrilled with the results and look forward to continued
                         collaboration.
                       </span>
-                    </fragment>
+                    
                   </span>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
       <link href="./index.css" rel="stylesheet" />
 
       <div class="home-container">
-        <navbar8-wrapper class="navbar8-wrapper">
+        <div class="navbar8-wrapper">
           <!--Navbar8 component-->
           <header class="navbar8-container1">
             <header data-thq="thq-navbar" class="navbar8-navbar-interactive">
@@ -74,17 +74,17 @@
                     href="https://www.teleporthq.io"
                     class="navbar8-link11 thq-link thq-body-small"
                   >
-                    <fragment class="home-fragment10">
+                    
                       <span class="home-text10">#home</span>
-                    </fragment>
+                    
                   </a>
                   <a
                     href="https://www.teleporthq.io"
                     class="thq-link thq-body-small"
                   >
-                    <fragment class="home-fragment11">
+                    
                       <span class="home-text11">#services</span>
-                    </fragment>
+                    
                   </a>
                   <a
                     href="https://www.teleporthq.io"
@@ -92,15 +92,15 @@
                     rel="noreferrer noopener"
                     class="navbar8-link31 thq-link thq-body-small"
                   >
-                    <fragment class="home-fragment12">
+                    
                       <span class="home-text12">#about</span>
-                    </fragment>
+                    
                   </a>
                   <div class="navbar8-link4-dropdown-trigger">
                     <span class="thq-link thq-body-small">
-                      <fragment class="home-fragment13">
+                      
                         <span class="home-text13">#contact</span>
-                      </fragment>
+                      
                     </span>
                     <div class="navbar8-icon-container1">
                       <div class="navbar8-container2">
@@ -121,18 +121,18 @@
                     class="navbar8-action11 thq-button-animated thq-button-filled"
                   >
                     <span>
-                      <fragment class="home-fragment18">
+                      
                         <span class="home-text18">Learn More</span>
-                      </fragment>
+                      
                     </span>
                   </button>
                   <button
                     class="navbar8-action21 thq-button-outline thq-button-animated"
                   >
                     <span>
-                      <fragment class="home-fragment19">
+                      
                         <span class="home-text19">Get in Touch</span>
-                      </fragment>
+                      
                     </span>
                   </button>
                 </div>
@@ -165,32 +165,32 @@
                       href="https://www.teleporthq.io"
                       class="navbar8-link12 thq-link thq-body-small"
                     >
-                      <fragment class="home-fragment10">
+                      
                         <span class="home-text10">#home</span>
-                      </fragment>
+                      
                     </a>
                     <a
                       href="https://www.teleporthq.io"
                       class="thq-link thq-body-small"
                     >
-                      <fragment class="home-fragment11">
+                      
                         <span class="home-text11">#services</span>
-                      </fragment>
+                      
                     </a>
                     <a
                       href="https://www.teleporthq.io"
                       class="navbar8-link32 thq-link thq-body-small"
                     >
-                      <fragment class="home-fragment12">
+                      
                         <span class="home-text12">#about</span>
-                      </fragment>
+                      
                     </a>
                     <div class="navbar8-link4-accordion">
                       <div class="navbar8-trigger">
                         <span class="thq-link thq-body-small">
-                          <fragment class="home-fragment13">
+                          
                             <span class="home-text13">#contact</span>
-                          </fragment>
+                          
                         </span>
                         <div class="navbar8-icon-container2">
                           <div class="navbar8-container4">
@@ -215,16 +215,16 @@
                             />
                             <div class="navbar8-content1">
                               <span class="navbar8-page11 thq-body-large">
-                                <fragment class="home-fragment14">
+                                
                                   <span class="home-text14">Home</span>
-                                </fragment>
+                                
                               </span>
                               <span class="thq-body-small">
-                                <fragment class="home-fragment20">
+                                
                                   <span class="home-text20">
                                     Welcome to ExpertTech Consulting LLC
                                   </span>
-                                </fragment>
+                                
                               </span>
                             </div>
                           </div>
@@ -238,14 +238,14 @@
                             />
                             <div class="navbar8-content2">
                               <span class="navbar8-page21 thq-body-large">
-                                <fragment class="home-fragment15">
+                                
                                   <span class="home-text15">Services</span>
-                                </fragment>
+                                
                               </span>
                               <span class="thq-body-small">
-                                <fragment class="home-fragment21">
+                                
                                   <span class="home-text21">Our Services</span>
-                                </fragment>
+                                
                               </span>
                             </div>
                           </div>
@@ -259,16 +259,16 @@
                             />
                             <div class="navbar8-content3">
                               <span class="navbar8-page31 thq-body-large">
-                                <fragment class="home-fragment16">
+                                
                                   <span class="home-text16">About Us</span>
-                                </fragment>
+                                
                               </span>
                               <span class="thq-body-small">
-                                <fragment class="home-fragment22">
+                                
                                   <span class="home-text22">
                                     About ExpertTech Consulting LLC
                                   </span>
-                                </fragment>
+                                
                               </span>
                             </div>
                           </div>
@@ -282,14 +282,14 @@
                             />
                             <div class="navbar8-content4">
                               <span class="navbar8-page41 thq-body-large">
-                                <fragment class="home-fragment17">
+                                
                                   <span class="home-text17">Contact</span>
-                                </fragment>
+                                
                               </span>
                               <span class="thq-body-small">
-                                <fragment class="home-fragment23">
+                                
                                   <span class="home-text23">Contact Us</span>
-                                </fragment>
+                                
                               </span>
                             </div>
                           </div>
@@ -300,16 +300,16 @@
                   <div class="navbar8-buttons2">
                     <button class="thq-button-filled">
                       <span>
-                        <fragment class="home-fragment18">
+                        
                           <span class="home-text18">Learn More</span>
-                        </fragment>
+                        
                       </span>
                     </button>
                     <button class="thq-button-outline">
                       <span>
-                        <fragment class="home-fragment19">
+                        
                           <span class="home-text19">Get in Touch</span>
-                        </fragment>
+                        
                       </span>
                     </button>
                   </div>
@@ -350,16 +350,16 @@
                       />
                       <div class="navbar8-content5">
                         <span class="navbar8-page12 thq-body-large">
-                          <fragment class="home-fragment14">
+                          
                             <span class="home-text14">Home</span>
-                          </fragment>
+                          
                         </span>
                         <span class="thq-body-small">
-                          <fragment class="home-fragment20">
+                          
                             <span class="home-text20">
                               Welcome to ExpertTech Consulting LLC
                             </span>
-                          </fragment>
+                          
                         </span>
                       </div>
                     </div>
@@ -373,14 +373,14 @@
                       />
                       <div class="navbar8-content6">
                         <span class="navbar8-page22 thq-body-large">
-                          <fragment class="home-fragment15">
+                          
                             <span class="home-text15">Services</span>
-                          </fragment>
+                          
                         </span>
                         <span class="thq-body-small">
-                          <fragment class="home-fragment21">
+                          
                             <span class="home-text21">Our Services</span>
-                          </fragment>
+                          
                         </span>
                       </div>
                     </div>
@@ -394,16 +394,16 @@
                       />
                       <div class="navbar8-content7">
                         <span class="navbar8-page32 thq-body-large">
-                          <fragment class="home-fragment16">
+                          
                             <span class="home-text16">About Us</span>
-                          </fragment>
+                          
                         </span>
                         <span class="thq-body-small">
-                          <fragment class="home-fragment22">
+                          
                             <span class="home-text22">
                               About ExpertTech Consulting LLC
                             </span>
-                          </fragment>
+                          
                         </span>
                       </div>
                     </div>
@@ -417,14 +417,14 @@
                       />
                       <div class="navbar8-content8">
                         <span class="navbar8-page42 thq-body-large">
-                          <fragment class="home-fragment17">
+                          
                             <span class="home-text17">Contact</span>
-                          </fragment>
+                          
                         </span>
                         <span class="thq-body-small">
-                          <fragment class="home-fragment23">
+                          
                             <span class="home-text23">Contact Us</span>
-                          </fragment>
+                          
                         </span>
                       </div>
                     </div>
@@ -434,8 +434,8 @@
             </header>
             <div class="navbar8-container8"></div>
           </header>
-        </navbar8-wrapper>
-        <hero17-wrapper class="hero17-wrapper">
+        </div>
+        <div class="hero17-wrapper">
           <!--Hero17 component-->
           <div class="hero17-header78">
             <div
@@ -443,12 +443,12 @@
             >
               <div class="hero17-content1">
                 <h1 class="hero17-text1 thq-heading-1">
-                  <fragment class="home-fragment27">
+                  
                     <span class="home-text27">AI Tech Consulting Services</span>
-                  </fragment>
+                  
                 </h1>
                 <p class="hero17-text2 thq-body-large">
-                  <fragment class="home-fragment26">
+                  
                     <span class="home-text26">
                       ExpertTech Consulting LLC, based in Boston, is a leading
                       provider of AI tech consulting services specializing in
@@ -459,22 +459,22 @@
                       satisfied clients highlight the effectiveness of their
                       solutions.
                     </span>
-                  </fragment>
+                  
                 </p>
               </div>
               <div class="hero17-actions">
                 <button class="thq-button-filled hero17-button1">
                   <span class="thq-body-small">
-                    <fragment class="home-fragment24">
+                    
                       <span class="home-text24">Contact us</span>
-                    </fragment>
+                    
                   </span>
                 </button>
                 <button class="thq-button-outline hero17-button2">
                   <span class="thq-body-small">
-                    <fragment class="home-fragment25">
+                    
                       <span class="home-text25">Learn more</span>
-                    </fragment>
+                    
                   </span>
                 </button>
               </div>
@@ -641,8 +641,8 @@
               </div>
             </div>
           </div>
-        </hero17-wrapper>
-        <features24-wrapper class="features24-wrapper">
+        </div>
+        <div class="features24-wrapper">
           <!--Features24 component-->
           <div class="thq-section-padding">
             <div class="features24-container2 thq-section-max-width">
@@ -670,17 +670,17 @@
                   </div>
                   <div class="features24-content1">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment28">
+                      
                         <span class="home-text28">Call Center Automation</span>
-                      </fragment>
+                      
                     </h2>
                     <span class="thq-body-small">
-                      <fragment class="home-fragment31">
+                      
                         <span class="home-text31">
                           Utilize AI to automate call center operations for
                           better customer service.
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -690,17 +690,17 @@
                   </div>
                   <div class="features24-content2">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment29">
+                      
                         <span class="home-text29">CRM Automation</span>
-                      </fragment>
+                      
                     </h2>
                     <span class="thq-body-small">
-                      <fragment class="home-fragment32">
+                      
                         <span class="home-text32">
                           Enhance CRM systems like Dynamics and Salesforce with
                           AI automation for improved efficiency.
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -710,27 +710,27 @@
                   </div>
                   <div class="features24-content3">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment30">
+                      
                         <span class="home-text30">
                           Invoice Processing Automation
                         </span>
-                      </fragment>
+                      
                     </h2>
                     <span class="thq-body-small">
-                      <fragment class="home-fragment33">
+                      
                         <span class="home-text33">
                           Automate invoice processing and AP/AR reconciliation
                           with AI technology.
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-        </features24-wrapper>
-        <cta26-wrapper class="cta26-wrapper">
+        </div>
+        <div class="cta26-wrapper">
           <!--CTA26 component-->
           <div class="thq-section-padding">
             <div class="thq-section-max-width">
@@ -739,20 +739,20 @@
                   <div class="cta26-container2">
                     <div class="cta26-content">
                       <span class="thq-heading-2">
-                        <fragment class="home-fragment36">
+                        
                           <span class="home-text36">
                             Ready to transform your business with AI?
                           </span>
-                        </fragment>
+                        
                       </span>
                       <p class="thq-body-large">
-                        <fragment class="home-fragment35">
+                        
                           <span class="home-text35">
                             Contact us today to learn more about our AI tech
                             consulting services and how we can help automate and
                             optimize your business processes.
                           </span>
-                        </fragment>
+                        
                       </p>
                     </div>
                     <div class="cta26-actions">
@@ -761,9 +761,9 @@
                         class="thq-button-filled cta26-button"
                       >
                         <span>
-                          <fragment class="home-fragment34">
+                          
                             <span class="home-text34">Contact Us</span>
-                          </fragment>
+                          
                         </span>
                       </button>
                     </div>
@@ -772,8 +772,8 @@
               </div>
             </div>
           </div>
-        </cta26-wrapper>
-        <features25-wrapper class="features25-wrapper">
+        </div>
+        <div class="features25-wrapper">
           <!--Features25 component-->
           <div class="thq-section-padding">
             <div class="features25-container2 thq-section-max-width">
@@ -784,17 +784,17 @@
                   </div>
                   <div class="features25-content1">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment37">
+                      
                         <span class="home-text37">Call Center Automation</span>
-                      </fragment>
+                      
                     </h2>
                     <span class="thq-body-small">
-                      <fragment class="home-fragment40">
+                      
                         <span class="home-text40">
                           Automate call center operations using AI technology to
                           improve efficiency and customer satisfaction.
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -804,17 +804,17 @@
                   </div>
                   <div class="features25-content2">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment38">
+                      
                         <span class="home-text38">Data Entry Automation</span>
-                      </fragment>
+                      
                     </h2>
                     <span class="thq-body-small">
-                      <fragment class="home-fragment41">
+                      
                         <span class="home-text41">
                           Streamline data entry processes through AI automation
                           for faster and more accurate data processing.
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -824,18 +824,18 @@
                   </div>
                   <div class="features25-content3">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment39">
+                      
                         <span class="home-text39">CRM Automation</span>
-                      </fragment>
+                      
                     </h2>
                     <span class="thq-body-small">
-                      <fragment class="home-fragment42">
+                      
                         <span class="home-text42">
                           Enhance customer relationship management with AI
                           automation in Dynamics, Salesforce, and other CRM
                           systems.
                         </span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
@@ -859,8 +859,8 @@
               </div>
             </div>
           </div>
-        </features25-wrapper>
-        <steps2-wrapper class="steps2-wrapper">
+        </div>
+        <div class="steps2-wrapper">
           <!--Steps2 component-->
           <div class="steps2-container1 thq-section-padding">
             <div class="steps2-max-width thq-section-max-width">
@@ -887,70 +887,70 @@
                 <div class="steps2-container3">
                   <div class="steps2-container4 thq-card">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment43">
+                      
                         <span class="home-text43">Initial Consultation</span>
-                      </fragment>
+                      
                     </h2>
                     <span class="steps2-text14 thq-body-small">
-                      <fragment class="home-fragment47">
+                      
                         <span class="home-text47">
                           Schedule a meeting with our AI tech experts to discuss
                           your business needs and goals.
                         </span>
-                      </fragment>
+                      
                     </span>
                     <label class="steps2-text15 thq-heading-3">01</label>
                   </div>
                   <div class="steps2-container5 thq-card">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment44">
+                      
                         <span class="home-text44">
                           Customized Solution Design
                         </span>
-                      </fragment>
+                      
                     </h2>
                     <span class="steps2-text17 thq-body-small">
-                      <fragment class="home-fragment48">
+                      
                         <span class="home-text48">
                           Our team will design a tailored AI solution based on
                           the consultation to meet your specific requirements.
                         </span>
-                      </fragment>
+                      
                     </span>
                     <label class="steps2-text18 thq-heading-3">02</label>
                   </div>
                   <div class="steps2-container6 thq-card">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment45">
+                      
                         <span class="home-text45">
                           Implementation and Integration
                         </span>
-                      </fragment>
+                      
                     </h2>
                     <span class="steps2-text20 thq-body-small">
-                      <fragment class="home-fragment49">
+                      
                         <span class="home-text49">
                           We will implement the AI solution seamlessly into your
                           existing systems and ensure smooth integration.
                         </span>
-                      </fragment>
+                      
                     </span>
                     <label class="steps2-text21 thq-heading-3">03</label>
                   </div>
                   <div class="steps2-container7 thq-card">
                     <h2 class="thq-heading-2">
-                      <fragment class="home-fragment46">
+                      
                         <span class="home-text46">Training and Support</span>
-                      </fragment>
+                      
                     </h2>
                     <span class="steps2-text23 thq-body-small">
-                      <fragment class="home-fragment50">
+                      
                         <span class="home-text50">
                           Provide training to your team on how to use the new AI
                           technology effectively and offer ongoing support for
                           any assistance needed.
                         </span>
-                      </fragment>
+                      
                     </span>
                     <label class="steps2-text24 thq-heading-3">04</label>
                   </div>
@@ -958,26 +958,26 @@
               </div>
             </div>
           </div>
-        </steps2-wrapper>
-        <testimonial17-wrapper class="testimonial17-wrapper">
+        </div>
+        <div class="testimonial17-wrapper">
           <!--Testimonial17 component-->
           <div class="thq-section-padding">
             <div class="testimonial17-max-width thq-section-max-width">
               <div class="testimonial17-container10">
                 <h2 class="thq-heading-2">
-                  <fragment class="home-fragment56">
+                  
                     <span class="home-text56">Testimonials</span>
-                  </fragment>
+                  
                 </h2>
                 <span class="testimonial17-text11 thq-body-small">
-                  <fragment class="home-fragment55">
+                  
                     <span class="home-text55">
                       ExpertTech Consulting LLC helped us automate our call
                       center operations efficiently. Their AI solutions have
                       significantly improved our customer service and overall
                       productivity.
                     </span>
-                  </fragment>
+                  
                 </span>
               </div>
               <div class="thq-grid-2">
@@ -995,25 +995,25 @@
                         />
                         <div class="testimonial17-container13">
                           <strong class="thq-body-large">
-                            <fragment class="home-fragment57">
+                            
                               <span class="home-text57">John Smith</span>
-                            </fragment>
+                            
                           </strong>
                           <span class="thq-body-small">
-                            <fragment class="home-fragment61">
+                            
                               <span class="home-text61">CEO, ABC Inc.</span>
-                            </fragment>
+                            
                           </span>
                         </div>
                       </div>
                       <span class="testimonial17-text14 thq-body-small">
-                        <fragment class="home-fragment51">
+                        
                           <span class="home-text51">
                             We are extremely satisfied with the services
                             provided by ExpertTech Consulting LLC. Their team is
                             highly skilled and professional.
                           </span>
-                        </fragment>
+                        
                       </span>
                     </div>
                   </div>
@@ -1032,26 +1032,26 @@
                         />
                         <div class="testimonial17-container15">
                           <strong class="thq-body-large">
-                            <fragment class="home-fragment58">
+                            
                               <span class="home-text58">Emily Johnson</span>
-                            </fragment>
+                            
                           </strong>
                           <span class="thq-body-small">
-                            <fragment class="home-fragment62">
+                            
                               <span class="home-text62">CFO, XYZ Corp.</span>
-                            </fragment>
+                            
                           </span>
                         </div>
                       </div>
                       <span class="testimonial17-text17 thq-body-small">
-                        <fragment class="home-fragment52">
+                        
                           <span class="home-text52">
                             ExpertTech Consulting LLC's AI automation for
                             invoice processing has streamlined our financial
                             operations. We highly recommend their services for
                             any business looking to enhance efficiency.
                           </span>
-                        </fragment>
+                        
                       </span>
                     </div>
                   </div>
@@ -1070,26 +1070,26 @@
                         />
                         <div class="testimonial17-container17">
                           <strong class="thq-body-large">
-                            <fragment class="home-fragment59">
+                            
                               <span class="home-text59">Michael Brown</span>
-                            </fragment>
+                            
                           </strong>
                           <span class="thq-body-small">
-                            <fragment class="home-fragment63">
+                            
                               <span class="home-text63">CTO, LMN Co.</span>
-                            </fragment>
+                            
                           </span>
                         </div>
                       </div>
                       <span class="testimonial17-text20 thq-body-small">
-                        <fragment class="home-fragment53">
+                        
                           <span class="home-text53">
                             The CRM automation solutions provided by ExpertTech
                             Consulting LLC have transformed our sales processes.
                             Their expertise in AI technology is truly
                             commendable.
                           </span>
-                        </fragment>
+                        
                       </span>
                     </div>
                   </div>
@@ -1108,28 +1108,28 @@
                         />
                         <div class="testimonial17-container19">
                           <strong class="thq-body-large">
-                            <fragment class="home-fragment60">
+                            
                               <span class="home-text60">Sarah Wilson</span>
-                            </fragment>
+                            
                           </strong>
                           <span class="thq-body-small">
-                            <fragment class="home-fragment64">
+                            
                               <span class="home-text64">
                                 Marketing Manager, PQR Ltd.
                               </span>
-                            </fragment>
+                            
                           </span>
                         </div>
                       </div>
                       <span class="testimonial17-text23 thq-body-small">
-                        <fragment class="home-fragment54">
+                        
                           <span class="home-text54">
                             ExpertTech Consulting LLC's AI lead generation
                             services have significantly boosted our marketing
                             efforts. We are thrilled with the results and look
                             forward to continued collaboration.
                           </span>
-                        </fragment>
+                        
                       </span>
                     </div>
                   </div>
@@ -1137,25 +1137,25 @@
               </div>
             </div>
           </div>
-        </testimonial17-wrapper>
-        <contact10-wrapper class="contact10-wrapper">
+        </div>
+        <div class="contact10-wrapper">
           <!--Contact10 component-->
           <div class="contact10-container1 thq-section-padding">
             <div class="contact10-max-width thq-section-max-width">
               <div class="contact10-content1 thq-flex-row">
                 <div class="contact10-content2">
                   <h2 class="thq-heading-2">
-                    <fragment class="home-fragment66">
+                    
                       <span class="home-text66">Locations</span>
-                    </fragment>
+                    
                   </h2>
                   <p class="thq-body-large">
-                    <fragment class="home-fragment65">
+                    
                       <span class="home-text65">
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                         Suspendisse varius enim in ero.
                       </span>
-                    </fragment>
+                    
                   </p>
                 </div>
               </div>
@@ -1167,12 +1167,12 @@
                     class="contact10-image1 thq-img-ratio-16-9"
                   />
                   <h3 class="contact10-text12 thq-heading-3">
-                    <fragment class="home-fragment67">
+                    
                       <span class="home-text67">Boston, MA, USA</span>
-                    </fragment>
+                    
                   </h3>
                   <p class="thq-body-large">
-                    <fragment class="home-fragment69">
+                    
                       <span class="home-text69">
                         ExpertTech Consulting LLC is proud to announce the
                         opening of our new location in Boston! Our team in
@@ -1185,7 +1185,7 @@
                         us today to learn more about how we can help your
                         business thrive with AI technology.
                       </span>
-                    </fragment>
+                    
                   </p>
                   <div class="contact10-container3">
                     <a
@@ -1205,12 +1205,12 @@
                     class="contact10-image2 thq-img-ratio-16-9"
                   />
                   <h3 class="contact10-text14 thq-heading-3">
-                    <fragment class="home-fragment68">
+                    
                       <span class="home-text68">Coimbatore, India</span>
-                    </fragment>
+                    
                   </h3>
                   <p class="thq-body-large">
-                    <fragment class="home-fragment70">
+                    
                       <span class="home-text70">
                         ExpertTech Consulting LLC offers AI tech consulting
                         services in Coimbatore, India to automate business
@@ -1220,7 +1220,7 @@
                         consultation, implementation, training, and support for
                         tailored AI solutions.
                       </span>
-                    </fragment>
+                    
                   </p>
                   <div class="contact10-container5">
                     <a
@@ -1236,8 +1236,8 @@
               </div>
             </div>
           </div>
-        </contact10-wrapper>
-        <footer4-wrapper class="footer4-wrapper">
+        </div>
+        <div class="footer4-wrapper">
           <!--Footer4 component-->
           <footer class="footer4-footer7 thq-section-padding">
             <div class="footer4-max-width thq-section-max-width">
@@ -1256,9 +1256,9 @@
                     rel="noreferrer noopener"
                     class="thq-body-small"
                   >
-                    <fragment class="home-fragment71">
+                    
                       <span class="home-text71">About Us</span>
-                    </fragment>
+                    
                   </a>
                   <a
                     href="https://example.com"
@@ -1266,9 +1266,9 @@
                     rel="noreferrer noopener"
                     class="thq-body-small"
                   >
-                    <fragment class="home-fragment72">
+                    
                       <span class="home-text72">Services</span>
-                    </fragment>
+                    
                   </a>
                   <a
                     href="https://example.com"
@@ -1276,9 +1276,9 @@
                     rel="noreferrer noopener"
                     class="thq-body-small"
                   >
-                    <fragment class="home-fragment73">
+                    
                       <span class="home-text73">Case Studies</span>
-                    </fragment>
+                    
                   </a>
                   <a
                     href="https://example.com"
@@ -1286,9 +1286,9 @@
                     rel="noreferrer noopener"
                     class="thq-body-small"
                   >
-                    <fragment class="home-fragment74">
+                    
                       <span class="home-text74">Blog</span>
-                    </fragment>
+                    
                   </a>
                   <a
                     href="https://example.com"
@@ -1296,9 +1296,9 @@
                     rel="noreferrer noopener"
                     class="thq-body-small"
                   >
-                    <fragment class="home-fragment75">
+                    
                       <span class="home-text75">Contact Us</span>
-                    </fragment>
+                    
                   </a>
                 </div>
               </div>
@@ -1310,26 +1310,26 @@
                   </div>
                   <div class="footer4-footer-links">
                     <span class="footer4-text11 thq-body-small">
-                      <fragment class="home-fragment78">
+                      
                         <span class="home-text78">Privacy Policy</span>
-                      </fragment>
+                      
                     </span>
                     <span class="thq-body-small">
-                      <fragment class="home-fragment76">
+                      
                         <span class="home-text76">Terms of Service</span>
-                      </fragment>
+                      
                     </span>
                     <span class="thq-body-small">
-                      <fragment class="home-fragment77">
+                      
                         <span class="home-text77">Cookies Policy</span>
-                      </fragment>
+                      
                     </span>
                   </div>
                 </div>
               </div>
             </div>
           </footer>
-        </footer4-wrapper>
+        </div>
       </div>
     </div>
     <script


### PR DESCRIPTION
## Summary
- clean up Teleport tags by removing fragment wrappers
- replace custom wrapper tags with standard `<div>` elements

## Testing
- `tidy -e index.html`
- `for f in components/*.html; do tidy -qe "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68728785a0d0832a87f2996ad92f221d